### PR TITLE
Fix docstring errors

### DIFF
--- a/contracts/Bin/InstaSave.sol
+++ b/contracts/Bin/InstaSave.sol
@@ -195,7 +195,7 @@ contract Helpers is DSMath {
 
     /**
      * @dev setting allowance to kyber for the "user proxy" if required
-     * @param token is the token
+     * @param tknContract is the token
      * @param srcAmt is the amount of token to sell
      */
     function setApproval(IERC20 tknContract, uint srcAmt) internal returns (uint) {
@@ -203,15 +203,6 @@ contract Helpers is DSMath {
         if (srcAmt > tokenAllowance) {
             tknContract.approve(getAddressKyber(), 2**255);
         }
-    }
-
-    /**
-     * @dev setting allowance to kyber for the "user proxy" if required
-     * @param token is the token
-     * @param srcAmt is the amount of token to sell
-     */
-    function getCDPRatio(uint ethCol, uint daiDebt) internal returns (uint ratio) {
-        TubInterface tub = TubInterface(getSaiTubAddress());
     }
 
 }

--- a/contracts/ProxyLogics/InstaKyber.sol
+++ b/contracts/ProxyLogics/InstaKyber.sol
@@ -105,7 +105,7 @@ contract Helper {
 
     /**
      * @dev setting allowance to kyber for the "user proxy" if required
-     * @param token is the token
+     * @param tknContract is the token
      * @param srcAmt is the amount of token to sell
      */
     function setApproval(IERC20 tknContract, uint srcAmt) internal returns (uint) {


### PR DESCRIPTION
`truffle compile` fails with the following:

```sh
$ truffle compile

Compiling your contracts...
===========================
> Compiling ./contracts/Bin/InstaBridgeOld.sol
> Compiling ./contracts/Bin/InstaSave.sol
> Compiling ./contracts/Bin/LightWallet.sol
> Compiling ./contracts/Bin/uni.sol
> Compiling ./contracts/ProxyLogics/InstaKyber.sol

Error: CompileError: DocstringParsingError: Documented parameter "token" not found in the parameter list of the function.
,DocstringParsingError: Documented parameter "token" not found in the parameter list of the function.
,DocstringParsingError: Documented parameter "srcAmt" not found in the parameter list of the function.
,DocstringParsingError: Documented parameter "token" not found in the parameter list of the function.
```

Fixes docstring parameter names and removes an unused function.